### PR TITLE
Spawn 0.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 
 FROM ubuntu:20.04
 ENV MODELON_LICENSE_PATH /home/simulator
-ENV SPAWN_FILE Spawn-0.2.0-98fa590817-Linux
+ENV SPAWN_VERSION v0.2.1
+ENV SPAWN_FILE Spawn-0.2.1-5d127d5774-Linux
 
 RUN apt update && apt install -y \
         libncurses5 \
@@ -11,7 +12,7 @@ RUN apt update && apt install -y \
 		vim \
     	wget && \
     cd /opt && \
-    wget https://spawn.s3.amazonaws.com/builds/${SPAWN_FILE}.tar.gz && \
+    wget https://github.com/NREL/Spawn/releases/download/${SPAWN_VERSION}/${SPAWN_FILE}.tar.gz && \
     tar xzf /opt/${SPAWN_FILE}.tar.gz && \
     mv /opt/${SPAWN_FILE}/ /opt/spawn && \
     ln -s /opt/spawn/bin/spawn /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a docker container for compiling and running Modelica-based code. The
 configuration uses `spawn` which has been extended to compile and simulate using either
 JModelica or Optimica. It can be configured to use a custom Modelica library, or by default, 
-contains LBNL's Modelica Building Library (Version 8.0).
+contains LBNL's Modelica Building Library (MBL) Version 8.0.
 
 This repository also contains several examples (which are also used in the unit tests).
 
@@ -35,30 +35,59 @@ path to the library, e.g., `-modelica-path /sim/mixed_loads /sim/modelica-buildi
 
 ## Running the Examples
 
+Launch a spawn-modelica container:
+
+__**Note: Mounting files into the container don't currently work because there is a permission issue with the FMU binaries. This is on the list to be addressed by `spawn`.**__
+
+```bash
+# with Optimica license
+docker run -it --rm --mac-address="<MAC_ADDRESS_OF_LICENSE>" -v $(pwd)/examples:/sim/mount spawn-fmu bash
+
+# w/o Optimica license
+docker run -it --rm -v $(pwd)/examples:/sim/mount spawn-fmu bash
+```
+
+Select an example to run from below, Flow, Load File, or Mixed Loads. The `--modelica-path` is only required if not using the built in version of the MBL.
+
+### Flow
+
+```bash
+cd /sim/examples
+spawn modelica --create-fmu Buildings.Controls.OBC.CDL.Continuous.Validation.Line --jmodelica
+spawn modelica --create-fmu Buildings.Controls.OBC.CDL.Continuous.Validation.Line --optimica
+
+# with mounted MBL
+spawn modelica --create-fmu Buildings.Controls.OBC.CDL.Continuous.Validation.Line --modelica-path /sim/examples/flow /sim/modelica-buildings/Buildings/ --jmodelica
+
+# running FMU
+spawn fmu --simulate Buildings_Controls_OBC_CDL_Continuous_Validation_Line.fmu --start 0.0 --stop 3600 --step 0.01
+```
+
+### Load File
+
+__**This file is currently not working**__
+
+```bash
+cd /sim/examples
+spawn modelica --create-fmu load_example.load_file --modelica-path /sim/examples/load_example --optimica
+spawn fmu --simulate load_file.fmu --start 0.0 --stop 86400 --step 3600
+```
+
+### Mixed Loads
+
+```bash
+cd /sim/examples
+# Optimica
+spawn modelica --create-fmu mixed_loads.Districts.DistrictEnergySystem --modelica-path /sim/examples/mixed_loads /sim/modelica-buildings/Buildings/ --optimica
+
+# JModelica
+spawn modelica --create-fmu mixed_loads.Districts.DistrictEnergySystem --modelica-path /sim/examples/mixed_loads /sim/modelica-buildings/Buildings/ --jmodelica
+
+# running FMU
+spawn fmu --simulate mixed_loads_Districts_DistrictEnergySystem.fmu --start 0.0 --stop 86400 --step 300
+```
 
 ## Running the Tests
 
 Run the tests with `py.test -s`. The `-s` is required to prevent the TTY error and turn off capture.
 
-# Run example
-#   docker run -it --rm --mac-address="f8:b1:56:c3:a9:af" -v $(pwd):/sim spawn-fmu bash
-#   spawn modelica --create-fmu mixed_loads.Districts.DistrictEnergySystem --modelica-path /sim/mixed_loads /sim/modelica-buildings/Buildings/ --optimica
-#   spawn modelica --create-fmu mixed_loads.Districts.DistrictEnergySystem --modelica-path /sim/mixed_loads /sim/modelica-buildings/Buildings/ --jmodelica
-#   spawn fmu --simulate mixed_loads_Districts_DistrictEnergySystem.fmu --start 0.0 --stop 86400 --step 300
-
-# Run example from mounted directory
-#   docker run -it --rm --mac-address="f8:b1:56:c3:a9:af" -v $(pwd):/sim/mount spawn-fmu bash  
-#   cd /sim/mount
-#   spawn modelica --create-fmu mixed_loads.Districts.DistrictEnergySystem --modelica-path /sim/mount/mixed_loads /sim/mount/modelica-buildings/Buildings/ --optimica
-
-# Run the load_file test
-#   docker run -it --rm --mac-address="f8:b1:56:c3:a9:af" spawn-fmu bash  
-#   cd /sim
-#   spawn modelica --create-fmu load_example.load_file --modelica-path /sim/load_example --optimica
-#   spawn fmu --simulate load_file.fmu --start 0.0 --stop 86400 --step 3600
-
-# Testing a non-DES version
-#   cd /sim
-#   spawn modelica --create-fmu Buildings.Controls.OBC.CDL.Continuous.Validation.Line --jmodelica
-#   spawn modelica --create-fmu Buildings.Controls.OBC.CDL.Continuous.Validation.Line --modelica-path /sim/mixed_loads /sim/modelica-buildings/Buildings/ --jmodelica
-#   spawn fmu --simulate Buildings_Controls_OBC_CDL_Continuous_Validation_Line.fmu --start 0.0 --stop 3600 --step 0.01


### PR DESCRIPTION
merge in the latest version of spawn. This includes updates for permissions which means that we should be able to mount external files into the container and run the models.